### PR TITLE
EASY-2473: content negotiation (html/pdf)

### DIFF
--- a/src/main/assembly/dist/res/template/style.css
+++ b/src/main/assembly/dist/res/template/style.css
@@ -64,13 +64,6 @@ footer p:first-child {
     text-align: right;
     background-color: #FFF;
 }
-@media print {
-  footer {
-    position: fixed;
-    bottom: 0;
-    padding-top: 18em;
-  }
-}
 .choice, .choice-header {
     padding-left: 5em;
 }

--- a/src/main/assembly/dist/res/template/style.css
+++ b/src/main/assembly/dist/res/template/style.css
@@ -38,7 +38,13 @@ footer {
     background-position: 96% 100%;
 }
 @media screen {
+    body, footer {
+        max-width: 500px;
+    }
     body {
+        margin-top: 100px; /* accommodate the logo */
+        background: #FFF url(data:image/jpg;base64,$DansLogo) no-repeat 0 0;
+        background-size: 262px 100px;
         margin-bottom: 9em;
     }
     footer {
@@ -57,6 +63,13 @@ footer p:first-child {
     margin-top: 2.5em;
     text-align: right;
     background-color: #FFF;
+}
+@media print {
+  footer {
+    position: fixed;
+    bottom: 0;
+    padding-top: 18em;
+  }
 }
 .choice, .choice-header {
     padding-left: 5em;

--- a/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorApp.scala
@@ -34,7 +34,7 @@ class EasyDepositAgreementGeneratorApp(configuration: Configuration) extends Deb
     trace(input)
     resource.managed(new ByteArrayOutputStream())
       .map(templateOS => {
-        if (contentType.contains("html"))
+        if (contentType.contains("/html"))
           for {
             placeholderMap <- placeholders.inputToPlaceholderMap(input)
             _ = logger.info(s"generating HTML: $contentType")

--- a/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorApp.scala
@@ -30,16 +30,24 @@ class EasyDepositAgreementGeneratorApp(configuration: Configuration) extends Deb
   private val pdfGenerator: PdfGenerator = new WeasyPrintPdfGenerator(configuration.pdfRunScript)
   private val processLogger: ProcessLogger = ProcessLogger(s => logger.info(s), e => logger.error(e))
 
-  def generateAgreement(input: AgreementInput, pdfOutputStream: => OutputStream): Try[Unit] = {
+  def generateAgreement(input: AgreementInput, docOutputStream: => OutputStream, contentType: String = "application/pdf"): Try[Unit] = {
     trace(input)
     resource.managed(new ByteArrayOutputStream())
       .map(templateOS => {
-        for {
-          placeholderMap <- placeholders.inputToPlaceholderMap(input)
-          _ <- templateResolver.createTemplate(templateOS, placeholderMap)
-          pdfInput = new ByteArrayInputStream(templateOS.toByteArray)
-          _ = pdfGenerator.createPdf(pdfInput, pdfOutputStream) ! processLogger
-        } yield ()
+        if (contentType.contains("html"))
+          for {
+            placeholderMap <- placeholders.inputToPlaceholderMap(input)
+            _ = logger.info(s"generating HTML: $contentType")
+            _ <- templateResolver.createTemplate(docOutputStream, placeholderMap)
+          } yield ()
+        else
+          for {
+            placeholderMap <- placeholders.inputToPlaceholderMap(input)
+            _ <- templateResolver.createTemplate(templateOS, placeholderMap)
+            _ = logger.info(s"generating PDF: $contentType")
+            pdfInput = new ByteArrayInputStream(templateOS.toByteArray)
+            _ = pdfGenerator.createPdf(pdfInput, docOutputStream) ! processLogger
+          } yield ()
       })
       .tried
       .flatten

--- a/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorServlet.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorServlet.scala
@@ -34,11 +34,12 @@ class EasyDepositAgreementGeneratorServlet(app: EasyDepositAgreementGeneratorApp
   }
 
   post("/agreement") {
-    contentType = if (request.getHeader("Accept") .contains("/html")) "text/html"
-      else "application/pdf"
+    contentType = if (request.getHeader("Accept").contains("/html"))
+                    "text/html;charset=utf-8"
+                  else "application/pdf"
 
     AgreementInput.fromJSON(request.body)
-      .flatMap(app.generateAgreement(_, response.outputStream, request.getHeader("Accept")))
+      .flatMap(app.generateAgreement(_, response.outputStream, contentType))
       .map(_ => Ok())
       .doIfFailure {
         case e =>

--- a/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorServlet.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/EasyDepositAgreementGeneratorServlet.scala
@@ -34,10 +34,11 @@ class EasyDepositAgreementGeneratorServlet(app: EasyDepositAgreementGeneratorApp
   }
 
   post("/agreement") {
-    contentType = "application/pdf"
+    contentType = if (request.getHeader("Accept") .contains("/html")) "text/html"
+      else "application/pdf"
 
     AgreementInput.fromJSON(request.body)
-      .flatMap(app.generateAgreement(_, response.outputStream))
+      .flatMap(app.generateAgreement(_, response.outputStream, request.getHeader("Accept")))
       .map(_ => Ok())
       .doIfFailure {
         case e =>

--- a/src/main/scala/nl/knaw/dans/easy/agreement/pdfgen/Placeholders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/pdfgen/Placeholders.scala
@@ -126,5 +126,4 @@ object Placeholders {
   } recoverWith {
     case e => Failure(PlaceholderException(e.getMessage, Option(e)))
   }
-
 }

--- a/src/main/scala/nl/knaw/dans/easy/agreement/pdfgen/Placeholders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/agreement/pdfgen/Placeholders.scala
@@ -19,6 +19,7 @@ import java.io.{ File => JFile }
 
 import better.files.File
 import nl.knaw.dans.easy.agreement._
+import nl.knaw.dans.easy.agreement.pdfgen.Placeholders.encodeImage
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.codec.binary.Base64
@@ -76,12 +77,6 @@ class V4AgreementPlaceholders(dansLogoFile: File, drivenByDataFile: File, licens
     )
   }
 
-  def encodeImage(keyword: KeywordMapping, file: File): Try[(KeywordMapping, String)] = Try {
-    keyword -> new String(Base64.encodeBase64(FileUtils.readFileToByteArray(file.toJava)))
-  } recoverWith {
-    case e => Failure(PlaceholderException(e.getMessage, Option(e)))
-  }
-
   def depositor(depositor: Depositor): PlaceholderMap = {
     Map(
       DepositorName -> depositor.name,
@@ -123,4 +118,13 @@ class V4AgreementPlaceholders(dansLogoFile: File, drivenByDataFile: File, licens
       Appendix3 -> file.toString.replaceAll(extensionRegExp, ".txt"),
     )
   }
+}
+object Placeholders {
+
+  def encodeImage(keyword: KeywordMapping, file: File): Try[(KeywordMapping, String)] = Try {
+    keyword -> new String(Base64.encodeBase64(FileUtils.readFileToByteArray(file.toJava)))
+  } recoverWith {
+    case e => Failure(PlaceholderException(e.getMessage, Option(e)))
+  }
+
 }

--- a/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
@@ -21,7 +21,7 @@ class TemplateMapSpec extends TestSupportFixture
 
   private val templateDir = testDir / "template"
 
-  // TODO a proper integration test starts with json to test it matches the template variations
+  // TODO a proper integration test starts with AgreementInput to test it matches the template variations
   def placeholderMap(isOpenAccess: Boolean, isSample: Boolean, available: Int): PlaceholderMap = Map(
     IsSample -> isSample.asInstanceOf[Object],
     OpenAccess -> isOpenAccess.asInstanceOf[Object],

--- a/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
@@ -78,8 +78,8 @@ class TemplateMapSpec extends TestSupportFixture
                 else ""
     val part1 = if (map(UnderEmbargo).asInstanceOf[Boolean]) "embargo-"
                 else ""
-    val part3 = if (map(OpenAccess).asInstanceOf[Boolean]) "OA"
-                else "RA"
+    val part3 = if (map(OpenAccess).asInstanceOf[Boolean]) "open"
+                else "restricted"
     s"$testDir/$part1$part2$part3.html"
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateMapSpec.scala
@@ -1,0 +1,85 @@
+package nl.knaw.dans.easy.agreement.pdfgen
+
+import java.io.ByteArrayOutputStream
+
+import better.files.File
+import nl.knaw.dans.easy.agreement.fixture.{ FileSystemSupport, TestSupportFixture }
+import nl.knaw.dans.easy.agreement.pdfgen.Placeholders.encodeImage
+import org.joda.time.{ DateTime, DateTimeZone }
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+
+import scala.util.Success
+
+class TemplateMapSpec extends TestSupportFixture
+  with TableDrivenPropertyChecks
+  with MockFactory
+  with FileSystemSupport
+  with BeforeAndAfterEach
+  with BeforeAndAfterAll {
+
+  private val templateDir = testDir / "template"
+
+  // TODO a proper integration test starts with json to test it matches the template variations
+  def placeholderMap(isOpenAccess: Boolean, isSample: Boolean, available: Int): PlaceholderMap = Map(
+    IsSample -> isSample.asInstanceOf[Object],
+    OpenAccess -> isOpenAccess.asInstanceOf[Object],
+    DateAvailable -> new DateTime(available, 12, 6, 0, 0, 0, DateTimeZone.UTC).asInstanceOf[Object],
+    UnderEmbargo -> (available > 2019).asInstanceOf[Object],
+    DateSubmitted -> "1992-07-30",
+    DepositorCity -> "Zürich",
+    Title -> "about &lt;a href='javascript:alert('XSS')'&gt;XSS&lt;/a&gt; escape &lt;b&gt;bold&lt;/b&gt; &lt;a href='http.dans.knaw.nl'&gt;linked&lt;/a&gt; content",
+    DepositorEmail -> "nobody@dans.knaw.nl",
+    DepositorOrganisation -> "Eidgenössische Technische Hochschule",
+    Appendix3 -> "/licenses/BY-NC-SA-3.0.txt",
+    TermsLicenseUrl -> "http://creativecommons.org/licenses/by-nc-sa/3.0",
+    DepositorPostalCode -> "8092",
+    TermsLicense -> "BY-NC-SA-3.0",
+    DepositorTelephone -> "+41 44 632 11 11",
+    DepositorName -> "N.O. Body",
+    DepositorCountry -> "Schweiz",
+    DepositorAddress -> "Rämistrasse 101",
+    DansManagedDoi -> "10.17026/dans-xn3-ptsa",
+    encodeImage(DansLogo, File("src/main/assembly/dist/res/dans_logo.png")).get,
+    encodeImage(DrivenByData, File("src/main/assembly/dist/res/DrivenByData.png")).get,
+  )
+
+  "template" should "find placeholders for all variants" in {
+    File("src/main/assembly/dist/res/template").copyTo(templateDir)
+    File("target/easy-licenses/licenses").copyTo(templateDir / "licenses")
+    val templateCreator = new VelocityTemplateResolver(templateDir, "Agreement.html")
+
+    val maps = for {
+      isOpenAccess <- Seq(true, false)
+      isSample <- Seq(true, false)
+      available <- Seq(2019, 2029)
+    } yield placeholderMap(isSample, isOpenAccess, available)
+
+    maps.map { map =>
+      val output = new ByteArrayOutputStream()
+      templateCreator.createTemplate(output, map).map { _ =>
+        // files are saved for (css) debugging purposes
+        // in case variants are broken, the message shows their file names
+        (testDir / docName(map)).write(new String(output.toByteArray)).name
+      }
+    } should matchPattern { case List(Success(_), Success(_), Success(_), Success(_), Success(_), Success(_), Success(_), Success(_)) => }
+
+    // just checking the length prevents huge messages when broken, and the length should be different anyway
+    testDir.list
+      .withFilter(_.name.endsWith(".html")).toArray
+      .map(_.contentAsString.length)
+      .distinct should have size 8
+    // TODO none of the documents contains badly serialized content like "Option(...)", "Seq(...)"?
+  }
+
+  private def docName(map: PlaceholderMap): String = {
+    val part2 = if (map(IsSample).asInstanceOf[Boolean]) "sample-"
+                else ""
+    val part1 = if (map(UnderEmbargo).asInstanceOf[Boolean]) "embargo-"
+                else ""
+    val part3 = if (map(OpenAccess).asInstanceOf[Boolean]) "OA"
+                else "RA"
+    s"$testDir/$part1$part2$part3.html"
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/agreement/pdfgen/TemplateSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.agreement.pdfgen
 
 import java.io.ByteArrayOutputStream
@@ -12,7 +27,7 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.util.Success
 
-class TemplateMapSpec extends TestSupportFixture
+class TemplateSpec extends TestSupportFixture
   with TableDrivenPropertyChecks
   with MockFactory
   with FileSystemSupport


### PR DESCRIPTION
fixes part of EASY-2473: content negotiation (html/pdf)

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Two screenshots of postman (note the accept value) followed by the json for the body:
![image](https://user-images.githubusercontent.com/10553630/70999638-14137400-20da-11ea-9c46-dc485eb6b7c6.png)

![image](https://user-images.githubusercontent.com/10553630/70999541-e3cbd580-20d9-11ea-9378-c7ac2cd8fd57.png)

```
{
      "depositor": {
            "name": "xxx",
            "address": "yyy",
            "zipcode": "zzz",
            "city": "aaa",
            "country": "Nederland",
            "organisation": "DANS/KNAW",
            "phone": "06-12345678",
            "email": "bbb@ccc.com"
      },
      "doi": "10.17026/test-dans-2xg-umq8",
      "title": "my first dataset",
      "dateSubmitted": "2019-12-06T10:02:00Z",
      "dateAvailable": "2019-11-06T10:02:00Z",
      "accessCategory": "OPEN_ACCESS",
      "license": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
      "sample": true,
      "agreementVersion": "4.0",
      "agreementLanguage": "EN"
}
```

#### related pull requests on github
`easy-deposit-api` needs this

