### PR TITLE
EASY-2510: add validation warning to API docs

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -43,7 +43,7 @@ paths:
         - agreement
       summary: Returns a Deposit Agreement based on the provided JSON
       requestBody:
-        description: JSON document containing the agreement request
+        description: JSON document containing the agreement request. Please note that this document is not validated by the server.
         required: true
         content:
           application/json:


### PR DESCRIPTION
fixes EASY-2510

#### When applied it will
* add a validation warning to the API docs

@DANS-KNAW/easy for review